### PR TITLE
docs(자료구조): 1주차 문제에서 예외처리를 할 수 있게 하기위해서  '오류 범위' 수정

### DIFF
--- a/Data-structure/1week/README.md
+++ b/Data-structure/1week/README.md
@@ -87,7 +87,7 @@ boolean add(int data);
 
 - `data`에 해당하는 숫자를 `list`의 맨 뒤에 추가하세요.
 
-- `data`가 `Integer range(–2,147,483,648 ~ 2,147,483,647)`를 넘어간다면 `IllegalArgumentException`를 발생시키세요.
+- `data`가 `range(–2,000,000,000 ~ 2,000,000,000)`를 넘어간다면 `IllegalArgumentException`를 발생시키세요.
 
   - Error Message
 


### PR DESCRIPTION
자꾸 수정해서 죄송함다....
이번 수정은 '정수 범위' 에 대한 정의를 수정했습니다.

## 수정한 이유
int 범위가 넘어가는 입력이 들어오면 예외 => 애초에 그 범위가 명시적으로 넘었을 때 컴파일러가 에러를 띄웁니다.
```java
add(10000000000000000000); // => 컴파일 단계에서 에러 발생
add(100000 * 10000000) // => 에러 발생x. 그러나 overflow발생. 따라서 예외처리를 못하는게 됨
```

따라서 -20억~+20억이라는 범위로 제한하여 에러를 발생시키고, 예외처리를 할 수 있도록 범위를 수정해야 했습니다.